### PR TITLE
feat: add port option

### DIFF
--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -321,12 +321,33 @@ def init_macos():
     NSBundle.mainBundle.bundleIdentifier = "net.activitywatch.ActivityWatch"
 
 
+def common_options(func):
+    """Common click options used across commands."""
+    options = [
+        click.option("--testing", is_flag=True, help="Enables testing mode."),
+        click.option(
+            "--port",
+            type=int,
+            default=None,
+            help="Port to connect to ActivityWatch server (default: 5600, or 5666 for testing).",
+        ),
+    ]
+    for option in reversed(options):
+        func = option(func)
+    return func
+
+
 @click.group(invoke_without_command=True)
 @click.pass_context
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
-@click.option("--testing", is_flag=True, help="Enables testing mode.")
-@click.option("--port", type=int, default=None, help="Port to connect to ActivityWatch server.")
+@common_options
 def main(ctx, verbose: bool, testing: bool, port: Optional[int]):
+    """
+    ActivityWatch notification service.
+
+    Sends notifications based on computer usage data from ActivityWatch.
+    Can connect to a custom ActivityWatch server port (default: 5600, or 5666 for testing).
+    """
     setup_logging("aw-notify", testing=testing, verbose=verbose, log_file=True)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logger.info("Starting...")
@@ -339,8 +360,7 @@ def main(ctx, verbose: bool, testing: bool, port: Optional[int]):
 
 
 @main.command()
-@click.option("--testing", is_flag=True, help="Enables testing mode.")
-@click.option("--port", type=int, default=None, help="Port to connect to ActivityWatch server.")
+@common_options
 def start(testing=False, port=None):
     """Start the notification service."""
     global aw, hostname

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -325,11 +325,14 @@ def init_macos():
 @click.pass_context
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 @click.option("--testing", is_flag=True, help="Enables testing mode.")
-@click.option("--port", type=int, default=5600, help="Port to connect to ActivityWatch server.")
+@click.option("--port", type=int, default=None, help="Port to connect to ActivityWatch server.")
 def main(ctx, verbose: bool, testing: bool, port: int):
     setup_logging("aw-notify", testing=testing, verbose=verbose, log_file=True)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logger.info("Starting...")
+
+    if port is None:
+        port = 5666 if testing else 5600
 
     if sys.platform == "darwin":
         init_macos()
@@ -340,10 +343,14 @@ def main(ctx, verbose: bool, testing: bool, port: int):
 
 @main.command()
 @click.option("--testing", is_flag=True, help="Enables testing mode.")
-@click.option("--port", type=int, default=5600, help="Port to connect to ActivityWatch server.")
-def start(testing=False, port=5600):
+@click.option("--port", type=int, default=None, help="Port to connect to ActivityWatch server.")
+def start(testing=False, port=None):
     """Start the notification service."""
     global aw, hostname
+
+    if port is None:
+        port = 5666 if testing else 5600
+
     aw = aw_client.ActivityWatchClient("aw-notify", testing=testing, port=port)
     aw.wait_for_start()
     hostname = aw.get_info().get("hostname", "unknown")

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -325,7 +325,8 @@ def init_macos():
 @click.pass_context
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 @click.option("--testing", is_flag=True, help="Enables testing mode.")
-def main(ctx, verbose: bool, testing: bool):
+@click.option("--port", type=int, default=5600, help="Port to connect to ActivityWatch server.")
+def main(ctx, verbose: bool, testing: bool, port: int):
     setup_logging("aw-notify", testing=testing, verbose=verbose, log_file=True)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logger.info("Starting...")
@@ -334,15 +335,16 @@ def main(ctx, verbose: bool, testing: bool):
         init_macos()
 
     if ctx.invoked_subcommand is None:
-        ctx.invoke(start, testing=testing)
+        ctx.invoke(start, testing=testing, port=port)
 
 
 @main.command()
 @click.option("--testing", is_flag=True, help="Enables testing mode.")
-def start(testing=False):
+@click.option("--port", type=int, default=5600, help="Port to connect to ActivityWatch server.")
+def start(testing=False, port=5600):
     """Start the notification service."""
     global aw, hostname
-    aw = aw_client.ActivityWatchClient("aw-notify", testing=testing)
+    aw = aw_client.ActivityWatchClient("aw-notify", testing=testing, port=port)
     aw.wait_for_start()
     hostname = aw.get_info().get("hostname", "unknown")
 

--- a/aw_notify/main.py
+++ b/aw_notify/main.py
@@ -326,13 +326,10 @@ def init_macos():
 @click.option("-v", "--verbose", is_flag=True, help="Verbose logging.")
 @click.option("--testing", is_flag=True, help="Enables testing mode.")
 @click.option("--port", type=int, default=None, help="Port to connect to ActivityWatch server.")
-def main(ctx, verbose: bool, testing: bool, port: int):
+def main(ctx, verbose: bool, testing: bool, port: Optional[int]):
     setup_logging("aw-notify", testing=testing, verbose=verbose, log_file=True)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
     logger.info("Starting...")
-
-    if port is None:
-        port = 5666 if testing else 5600
 
     if sys.platform == "darwin":
         init_macos()
@@ -347,9 +344,6 @@ def main(ctx, verbose: bool, testing: bool, port: int):
 def start(testing=False, port=None):
     """Start the notification service."""
     global aw, hostname
-
-    if port is None:
-        port = 5666 if testing else 5600
 
     aw = aw_client.ActivityWatchClient("aw-notify", testing=testing, port=port)
     aw.wait_for_start()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Adds `--port` option to `main` and `start` in `aw_notify/main.py` for custom ActivityWatch server port, with default 5600 or 5666 for testing.
> 
>   - **Behavior**:
>     - Adds `--port` option to `main` and `start` functions in `aw_notify/main.py` to specify custom ActivityWatch server port.
>     - Default port is 5600, or 5666 for testing mode.
>   - **Functions**:
>     - Introduces `common_options` decorator to consolidate shared Click options.
>     - Updates `ActivityWatchClient` initialization to use specified `port` in `start` function.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-notify&utm_source=github&utm_medium=referral)<sup> for d8e96c50a95a3946a241bc868cff1dd07be1a995. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->